### PR TITLE
Better center of header circles

### DIFF
--- a/app/src/stylesheets/_header.scss
+++ b/app/src/stylesheets/_header.scss
@@ -11,7 +11,7 @@ header {
             color: white;
             text-decoration: none;
             display: inline-block;
-            margin-right: 5%;
+            min-width: 15%;
 
             &:hover {
                 color: grey;


### PR DESCRIPTION
From
<img width="692" alt="screen shot 2015-11-26 at 12 27 04" src="https://cloud.githubusercontent.com/assets/692215/11423062/192eed7a-9439-11e5-98ee-0efa65c40f29.png">
To
<img width="699" alt="screen shot 2015-11-26 at 12 26 40" src="https://cloud.githubusercontent.com/assets/692215/11423061/1929933e-9439-11e5-8292-d16ce143907b.png">

Closes https://github.com/te-chie-la/techiela-web/issues/14
